### PR TITLE
Fix: Add isRaspberryPi field persistence for display settings

### DIFF
--- a/src/lib/services/display-service.ts
+++ b/src/lib/services/display-service.ts
@@ -41,6 +41,7 @@ class DisplayService {
         playlistId: input.assignedPlaylistId || null,
         isOnline: false,
         clockSettings: input.clockSettings || {},
+        isRaspberryPi: input.isRaspberryPi || false,
       },
       include: {
         playlist: {
@@ -164,6 +165,7 @@ class DisplayService {
     if (input.resolution !== undefined) updateData.resolution = input.resolution;
     if (input.orientation !== undefined) updateData.orientation = input.orientation as DisplayOrientation;
     if (input.assignedPlaylistId !== undefined) updateData.playlistId = input.assignedPlaylistId;
+    if (input.isRaspberryPi !== undefined) updateData.isRaspberryPi = input.isRaspberryPi;
     
     // Handle clockSettings - ensure it's a valid JSON object
     if (input.clockSettings !== undefined) {

--- a/src/lib/validators/display-schemas.ts
+++ b/src/lib/validators/display-schemas.ts
@@ -69,6 +69,7 @@ export const CreateDisplaySchema = z.object({
   assignedPlaylistId: z.string().uuid('Playlist ID must be a valid UUID').optional().nullable(),
   settings: DisplaySettingsSchema.optional(),
   clockSettings: z.any().optional(), // JSON clock configuration
+  isRaspberryPi: z.boolean().optional().default(false), // Raspberry Pi optimization flag
 });
 
 /**
@@ -89,6 +90,7 @@ export const UpdateDisplaySchema = z.object({
   assignedPlaylistId: z.string().uuid('Playlist ID must be a valid UUID').optional().nullable(),
   settings: DisplaySettingsSchema.optional(),
   clockSettings: z.any().optional(), // JSON clock configuration
+  isRaspberryPi: z.boolean().optional(), // Raspberry Pi optimization flag
 });
 
 /**


### PR DESCRIPTION
## Summary
- Adds missing `isRaspberryPi` field to display validation schemas and service methods
- Ensures the Raspberry Pi toggle in display settings properly persists to database
- Fixes issue where toggling a display as Raspberry Pi would not save the state

## Changes
- Added `isRaspberryPi` field to `CreateDisplaySchema` and `UpdateDisplaySchema` in validation schemas
- Updated display service to handle the `isRaspberryPi` field in create and update operations
- Field properly persists when editing existing displays

## Test Plan
- [x] Toggle Raspberry Pi setting on existing display
- [x] Verify setting persists after closing and reopening settings
- [x] Create new display with Raspberry Pi toggle enabled
- [x] Verify database properly stores the field value

This PR completes the Raspberry Pi optimization feature by ensuring the toggle state is properly saved to the database.

🤖 Generated with [Claude Code](https://claude.ai/code)