### PR TITLE
Fix: Complete isRaspberryPi field persistence throughout data pipeline

### DIFF
--- a/src/lib/services/display-service.ts
+++ b/src/lib/services/display-service.ts
@@ -366,6 +366,7 @@ class DisplayService {
       isActive: true,  // Always true since we don't have soft delete
       settings: {},  // No settings field in schema
       clockSettings: display.clockSettings || {},
+      isRaspberryPi: display.isRaspberryPi || false,
     };
   }
 }

--- a/src/lib/transformers/api-transformers.ts
+++ b/src/lib/transformers/api-transformers.ts
@@ -162,6 +162,7 @@ export function apiToFrontendDisplay(apiDisplay: ApiDisplayResponse) {
     isActive: apiDisplay.isActive !== undefined ? apiDisplay.isActive : true,
     status: status,
     location: apiDisplay.location,
+    isRaspberryPi: apiDisplay.isRaspberryPi || false,
     createdAt: new Date(apiDisplay.createdAt),
     updatedAt: new Date(apiDisplay.updatedAt),
   };
@@ -547,6 +548,7 @@ export function databaseToApiDisplay(dbDisplay: any): ApiDisplayResponse {
     orientation: dbDisplay.orientation,
     location: dbDisplay.location,
     isActive: dbDisplay.isActive,
+    isRaspberryPi: dbDisplay.isRaspberryPi || false,
     playlistId: dbDisplay.playlistId,
     lastSeen: dbDisplay.lastSeen?.toISOString() || null,
     createdAt: dbDisplay.createdAt.toISOString(),

--- a/src/lib/types/api-types.ts
+++ b/src/lib/types/api-types.ts
@@ -138,6 +138,7 @@ export interface ApiDisplayResponse {
   lastSeen: string | null;
   isOnline?: boolean;
   isActive?: boolean;
+  isRaspberryPi?: boolean;
   location: string | null;
   createdAt: string;
   updatedAt: string;
@@ -217,6 +218,7 @@ export interface CreateDisplayRequest {
   resolution?: string;
   orientation?: DisplayOrientation;
   location?: string;
+  isRaspberryPi?: boolean;
 }
 
 /**
@@ -228,4 +230,5 @@ export interface UpdateDisplayRequest {
   resolution?: string;
   orientation?: DisplayOrientation;
   location?: string;
+  isRaspberryPi?: boolean;
 }


### PR DESCRIPTION
## Summary
- Fixes the isRaspberryPi toggle not persisting when editing displays
- Completes the data transformation pipeline for the isRaspberryPi field

## Root Cause
The `formatDisplay` method in `display-service.ts` was not including the `isRaspberryPi` field when formatting display objects from the database. This caused the value to be lost even though it was correctly saved to the database.

## Changes
1. **API Types** (`api-types.ts`)
   - Added `isRaspberryPi` to `ApiDisplayResponse` interface
   - Added field to `CreateDisplayRequest` and `UpdateDisplayRequest` interfaces

2. **API Transformers** (`api-transformers.ts`)
   - Added `isRaspberryPi` field to `apiToFrontendDisplay` function
   - Added field to `databaseToApiDisplay` function  

3. **Display Service** (`display-service.ts`)
   - Added `isRaspberryPi` field to the `formatDisplay` method's return object
   - This was the critical missing piece preventing persistence

## Test Plan
- [x] Toggle Raspberry Pi setting on existing display
- [x] Save and close the modal
- [x] Reopen the display settings
- [x] Verify the toggle state persists correctly
- [x] Check database shows correct isRaspberryPi value
- [x] Verify display receives the setting for performance optimizations

This fix ensures that the Raspberry Pi toggle properly persists across all layers of the application.

🤖 Generated with [Claude Code](https://claude.ai/code)